### PR TITLE
fix: MCD-610: Update gitHub Actions and fix Drupal 11 compatibility

### DIFF
--- a/.github/workflows/test-drupal-setup.yml
+++ b/.github/workflows/test-drupal-setup.yml
@@ -15,13 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup PHP
-        run: |
-          sudo update-alternatives --set php /usr/bin/php8.1
+        uses: drunomics/setup-php@v2
+        with:
+          php-version: '8.1'
       - name: "Determine composer cache directory"
         id: "determine-composer-cache-directory"
-        run: "echo \"::set-output name=directory::$(composer config cache-dir)\""
+        run: echo "directory=$(composer config cache-dir)" >> $GITHUB_OUTPUT
       - name: "Cache dependencies installed with composer"
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v4
         with:
           path: "${{ steps.determine-composer-cache-directory.outputs.directory }}"
           key: ${{ runner.os }}-composer-v1-${{ hashFiles('./composer.json') }}

--- a/.github/workflows/test-drupal-setup.yml
+++ b/.github/workflows/test-drupal-setup.yml
@@ -41,6 +41,7 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: |
           export COMPOSE_DEFAULT_USER=$(id -u $USER)
+          docker compose build cli
           docker compose up -d
           echo "Waiting for mysql to come up..." && docker exec -it $(docker compose ps -q cli) /bin/bash -c "while ! echo exit | nc mariadb 3306; do sleep 1; done" >/dev/null
       - name: Install the project

--- a/.github/workflows/test-drupal-setup.yml
+++ b/.github/workflows/test-drupal-setup.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: drunomics/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
       - name: "Determine composer cache directory"
         id: "determine-composer-cache-directory"
         run: echo "directory=$(composer config cache-dir)" >> $GITHUB_OUTPUT
@@ -50,4 +50,4 @@ jobs:
           docker compose exec cli phapp install --no-build
       - name: Check connection and response of the site
         run: |
-          curl -v http://example.drupal-project.localdev.space | grep "Drupal 10"
+          curl -v http://example.drupal-project.localdev.space | grep "Drupal 11"

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Builds upon https://github.com/drupal-composer/drupal-project.
 
 ## Version compatibility
 
-| Git branch/tag: | Drupal core: |
-|---              | ---          |
-| 5.x             | Drupal 8     |
-| 6.x             | Drupal 9+    |
+| Git branch/tag: | Drupal core: | PHP version: |
+|---              | ---          | ---          |
+| 5.x             | Drupal 8     | 7.x          |
+| 6.x             | Drupal 11+   | 8.3+         |
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
     ],
     "require": {
         "cweagans/composer-patches": "^1.7.2",
-        "drupal/core-composer-scaffold": "^10",
-        "drupal/core-recommended": "^10",
+        "drupal/core-composer-scaffold": "^11",
+        "drupal/core-recommended": "^11",
         "drush/drush": "*",
         "oomphinc/composer-installers-extender": "^2.0.1",
-        "symfony/dotenv": "^5.4.22"
+        "symfony/dotenv": "^7.0"
     },
     "require-dev": {
-        "drupal/core-dev": "^10",
+        "drupal/core-dev": "^11",
         "drunomics/playwright-drupal-utils": "^1.0.0"
     },
     "conflict": {
@@ -133,7 +133,7 @@
     },
     "config": {
         "platform": {
-            "php": "8.1"
+            "php": "8.3"
         },
         "sort-packages": true,
         "preferred-install": {

--- a/scripts/init-devsetup-docker.sh
+++ b/scripts/init-devsetup-docker.sh
@@ -29,6 +29,6 @@ if [[ $PROJECT_ADD_DEVSETUP_DOCKER = 1 ]]; then
   rm -rf devsetup-tmp process-replacements.php
   echo \
 'COMPOSE_AMAZEEIO_VERSION=25.9.0
-COMPOSE_AMAZEEIO_PHP_VERSION=8.1
+COMPOSE_AMAZEEIO_PHP_VERSION=8.3
 ' >> .env-defaults
 fi

--- a/scripts/init-devsetup-docker.sh
+++ b/scripts/init-devsetup-docker.sh
@@ -9,7 +9,7 @@ if [[ $PROJECT_ADD_DEVSETUP_DOCKER = 1 ]]; then
   echo "Adding devsetup-docker from https://github.com/drunomics/devsetup-docker..."
   echo "Set PROJECT_ADD_DEVSETUP_DOCKER=0 to disable."
 
-  git clone https://github.com/drunomics/devsetup-docker.git --branch=feature/MCD-610 devsetup-tmp
+  git clone https://github.com/drunomics/devsetup-docker.git --branch=3.x devsetup-tmp
   rm -rf devsetup-tmp/.git devsetup-tmp/README.md
 
   # OS specific cp operations

--- a/scripts/init-devsetup-docker.sh
+++ b/scripts/init-devsetup-docker.sh
@@ -28,7 +28,7 @@ if [[ $PROJECT_ADD_DEVSETUP_DOCKER = 1 ]]; then
   php process-replacements.php
   rm -rf devsetup-tmp process-replacements.php
   echo \
-'COMPOSE_AMAZEEIO_VERSION=22.2.0
+'COMPOSE_AMAZEEIO_VERSION=25.12.0
 COMPOSE_AMAZEEIO_PHP_VERSION=8.1
 ' >> .env-defaults
 fi

--- a/scripts/init-devsetup-docker.sh
+++ b/scripts/init-devsetup-docker.sh
@@ -9,7 +9,7 @@ if [[ $PROJECT_ADD_DEVSETUP_DOCKER = 1 ]]; then
   echo "Adding devsetup-docker from https://github.com/drunomics/devsetup-docker..."
   echo "Set PROJECT_ADD_DEVSETUP_DOCKER=0 to disable."
 
-  git clone https://github.com/drunomics/devsetup-docker.git --branch=3.x devsetup-tmp
+  git clone https://github.com/drunomics/devsetup-docker.git --branch=feature/MCD-610 devsetup-tmp
   rm -rf devsetup-tmp/.git devsetup-tmp/README.md
 
   # OS specific cp operations

--- a/scripts/init-devsetup-docker.sh
+++ b/scripts/init-devsetup-docker.sh
@@ -28,7 +28,7 @@ if [[ $PROJECT_ADD_DEVSETUP_DOCKER = 1 ]]; then
   php process-replacements.php
   rm -rf devsetup-tmp process-replacements.php
   echo \
-'COMPOSE_AMAZEEIO_VERSION=25.12.0
+'COMPOSE_AMAZEEIO_VERSION=25.9.0
 COMPOSE_AMAZEEIO_PHP_VERSION=8.1
 ' >> .env-defaults
 fi

--- a/web/sites/development.settings.php
+++ b/web/sites/development.settings.php
@@ -1,7 +1,11 @@
 <?php
 
-assert_options(ASSERT_ACTIVE, TRUE);
-\Drupal\Component\Assertion\Handle::register();
+/**
+ * @file
+ * Contains Drupal settings for development sites.
+ */
+
+ini_set('zend.assertions', 1);
 
 /**
  * Enable local development services.


### PR DESCRIPTION
- Update actions/cache from v2.1.5 to v4
- Replace deprecated set-output with $GITHUB_OUTPUT