### PR TITLE
build: MCD-1133: Scope packages.drupal.org Composer repo to drupal/*.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         },
         {
             "type": "composer",
-            "url": "https://packages.drupal.org/8"
+            "url": "https://packages.drupal.org/8",
+            "only": ["drupal/*"]
         },
         {
             "type": "composer",


### PR DESCRIPTION
Adds `"only": ["drupal/*"]` to the `https://packages.drupal.org/8` Composer repository in the project template, so new mossbo cloud projects inherit the explicit scoping.

## Important finding — no measurable speedup on this facade

`packages.drupal.org/8` already advertises `available-package-patterns: ["drupal/*"]`; Composer 2 already honours it and never queries the facade for non-`drupal/*` packages. Before/after `composer update` request counts (measured on ldp-project, same facade) are identical. The 2,500→30 win reported originally was on a **private** facade (drunomics GitLab) that does not advertise the pattern.

So this is harmless hygiene / explicit scoping, not a performance fix. See MCD-1133 for the full measurement. Close instead if the cosmetic change is not wanted.

Refs: MCD-1133

_Drafted with Claude Code from claude-vm-2._